### PR TITLE
fix: Revert dynamic sampling to original avg-reward based filtering

### DIFF
--- a/examples/scripts/train_dapo_ray_hybrid_engine.sh
+++ b/examples/scripts/train_dapo_ray_hybrid_engine.sh
@@ -1,0 +1,68 @@
+set -x
+
+python3 -m openrlhf.cli.train_ppo_ray \
+   --ref_num_nodes 1 \
+   --ref_num_gpus_per_node 8 \
+   --actor_num_nodes 1 \
+   --actor_num_gpus_per_node 8 \
+   --vllm_num_engines 4 \
+   --vllm_tensor_parallel_size 2 \
+   --colocate_all_models \
+   --vllm_gpu_memory_utilization 0.6 \
+   --init_kl_coef 0.0 \
+   --kl_target 0.0 \
+   --gamma 1.0 \
+   --advantage_estimator group_norm \
+   --pretrain OpenRLHF/Llama-3-8b-sft-mixture \
+   --agent_func_path examples/python/agent_func.py \
+   --save_path /openrlhf/examples/test_scripts/final/llama3-8b-dapo \
+   --ckpt_path /openrlhf/examples/test_scripts/ckpt/llama3-8b-dapo \
+   --save_hf_ckpt \
+   --micro_train_batch_size 8 \
+   --train_batch_size 128 \
+   --micro_rollout_batch_size 16 \
+   --rollout_batch_size 128 \
+   --n_samples_per_prompt 8 \
+   --max_epochs 1 \
+   --prompt_max_len 1024 \
+   --max_samples 100000 \
+   --generate_max_len 1024 \
+   --zero_stage 3 \
+   --bf16 \
+   --actor_learning_rate 5e-7 \
+   --critic_learning_rate 9e-6 \
+   --prompt_data OpenRLHF/prompt-collection-v0.1 \
+   --input_key context_messages \
+   --apply_chat_template \
+   --normalize_reward \
+   --gradient_checkpointing \
+   --packing_samples \
+   --vllm_sync_backend nccl \
+   --enforce_eager \
+   --vllm_enable_sleep \
+   --deepspeed_enable_sleep \
+   --dapo_clip_eps_low 0.2 \
+   --dapo_clip_eps_high 0.28 \
+   --dynamic_filtering \
+   --dapo_enable_overlong_filtering \
+   --enable_dapo_overlong_reward_shaping \
+   --dapo_l_max 20480 \
+   --dapo_l_cache 4096
+
+# Notes on changes from GRPO script for DAPO:
+# - Removed --reward_pretrain, --reward_num_nodes, --reward_num_gpus_per_node
+# - Added --agent_func_path for rule-based rewards
+# - Set --init_kl_coef 0.0 and --kl_target 0.0 (or remove kl_target)
+# - Removed --use_kl_loss and --kl_estimator
+# - Added DAPO specific arguments:
+#   --dapo_clip_eps_low, --dapo_clip_eps_high
+#   --dynamic_filtering (explicitly added)
+#   --dapo_enable_overlong_filtering
+#   --enable_dapo_overlong_reward_shaping
+#   --dapo_l_max, --dapo_l_cache
+# - Kept --advantage_estimator group_norm as DAPO modifies loss/rewards, not necessarily estimator type.
+# - Save paths updated to reflect 'dapo'.
+# - Critic model will default to --pretrain as per logic when agent_func_path is used.
+# - --eps_clip is not used by PolicyLoss if dapo_clip_eps_low/high are used, so it's implicitly removed from effect.
+# - --dynamic_filtering_reward_range removed as it's not used by DAPO's dynamic filtering.
+# - Ensure examples/python/agent_func.py is adapted for DAPO's +1/-1 reward logic.

--- a/openrlhf/cli/train_ppo_ray.py
+++ b/openrlhf/cli/train_ppo_ray.py
@@ -316,6 +316,8 @@ if __name__ == "__main__":
     parser.add_argument("--l2", type=float, default=0.0, help="weight decay loss")
     parser.add_argument("--ptx_coef", type=float, default=0.05, help="PPO-ptx loss coef")
     parser.add_argument("--eps_clip", type=float, default=0.2, help="PPO clip range")
+    parser.add_argument("--dapo_clip_eps_low", type=float, default=0.2, help="DAPO lower clip range")
+    parser.add_argument("--dapo_clip_eps_high", type=float, default=0.28, help="DAPO upper clip range")
     parser.add_argument("--value_clip", type=float, default=0.2, help="PPO value clip range")
     parser.add_argument("--lambd", type=float, default=1, help="PPO GAE lambd")
     parser.add_argument("--gamma", type=float, default=1, help="PPO GAE gamma")
@@ -355,6 +357,22 @@ if __name__ == "__main__":
     parser.add_argument("--entropy_loss_coef", type=float, default=0, help="Entropy loss coef")
     parser.add_argument("--adam_betas", type=float, nargs=2, default=(0.9, 0.95), help="Betas for Adam optimizer")
     parser.add_argument("--reward_clip_range", type=float, nargs=2, default=(-10, 10), help="Reward clip range")
+
+    # DAPO arguments
+    parser.add_argument("--dapo_l_max", type=int, default=20480, help="DAPO L_max for overlong reward shaping.")
+    parser.add_argument("--dapo_l_cache", type=int, default=4096, help="DAPO L_cache for overlong reward shaping.")
+    parser.add_argument(
+        "--enable_dapo_overlong_reward_shaping",
+        action="store_true",
+        default=False,
+        help="Enable DAPO overlong reward shaping (soft punishment R_length).",
+    )
+    parser.add_argument(
+        "--dapo_enable_overlong_filtering",
+        action="store_true",
+        default=False,
+        help="Enable DAPO overlong filtering (mask loss for truncated samples).",
+    )
 
     # DisCO arguments
     parser.add_argument(

--- a/openrlhf/models/loss.py
+++ b/openrlhf/models/loss.py
@@ -77,9 +77,10 @@ class PolicyLoss(nn.Module):
     Policy Loss for PPO
     """
 
-    def __init__(self, clip_eps: float = 0.2, token_level_loss: bool = True) -> None:
+    def __init__(self, clip_eps_low: float = 0.2, clip_eps_high: float = 0.28, token_level_loss: bool = True) -> None:
         super().__init__()
-        self.clip_eps = clip_eps
+        self.clip_eps_low = clip_eps_low
+        self.clip_eps_high = clip_eps_high
         self.token_level_loss = token_level_loss
 
     def forward(
@@ -91,7 +92,7 @@ class PolicyLoss(nn.Module):
     ) -> torch.Tensor:
         ratio = (log_probs - old_log_probs).exp()
         surr1 = ratio * advantages
-        surr2 = ratio.clamp(1 - self.clip_eps, 1 + self.clip_eps) * advantages
+        surr2 = ratio.clamp(1 - self.clip_eps_low, 1 + self.clip_eps_high) * advantages
         loss = -torch.min(surr1, surr2)
         loss = (
             masked_mean(loss, action_mask, dim=None)

--- a/openrlhf/tests/test_models_utils.py
+++ b/openrlhf/tests/test_models_utils.py
@@ -1,0 +1,187 @@
+import torch
+from torch.testing import assert_close
+import unittest
+
+# Assuming compute_reward is in openrlhf.models.utils
+from openrlhf.models.utils import compute_reward
+
+# Helper function to create tensors
+DTYPE = torch.float32
+DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+def _t(data, dtype=DTYPE, device=DEVICE):
+    if not isinstance(data, torch.Tensor):
+        data = torch.tensor(data, dtype=dtype, device=device)
+    return data.to(device)
+
+
+class TestModelsUtils(unittest.TestCase):
+
+    def test_compute_reward_dapo_overlong_shaping(self):
+        # Dummy inputs for compute_reward that are not directly involved in R_length
+        kl_dummy = _t([[0.0, 0.0], [0.0, 0.0]]) # (batch_size, action_len)
+        action_mask_dummy = _t([[True, True], [True, True]], dtype=torch.bool)
+
+        # Test Case 1: length <= l_max - l_cache
+        # R_length should be 0
+        r_original_1 = _t([1.0, 0.5]) # Batch size of 2
+        response_lengths_1 = _t([1000, 2000])
+        dapo_args_1 = {
+            "enable_dapo_overlong_reward_shaping": True,
+            "dapo_l_max": 20480,
+            "dapo_l_cache": 4096 # Threshold for penalty: 20480 - 4096 = 16384
+        }
+        # Expected r = r_original + 0
+        # compute_reward will scatter this to the last token and add kl_reward (which is 0 if kl_coef=0)
+        # We are testing the value of 'r' before scattering and kl_reward addition.
+        # The function compute_reward applies R_length, then clips r, then adds kl_reward to last token.
+        # To isolate R_length, we'll check the 'r' value after R_length is applied.
+        # The function returns the final per-token reward. We need to check the effect on the magnitude of 'r'.
+        
+        # Let's assume kl_coef = 0 for simplicity to isolate R_length effect on the final reward value.
+        # The reward 'r' input to compute_reward is per-sequence.
+        # The output of compute_reward is per-token.
+        # If r_length is 0, the per-sequence reward 'r' passed to scatter should be r_original_1.
+        # So, last_reward should be r_original_1 at EOS, kl_reward is 0.
+        expected_reward_output_1_seq0_val = r_original_1[0].item()
+        expected_reward_output_1_seq1_val = r_original_1[1].item()
+
+        final_rewards_1 = compute_reward(
+            r=r_original_1.clone(), kl_coef=0.0, kl=kl_dummy.clone(), action_mask=action_mask_dummy.clone(),
+            response_lengths=response_lengths_1.clone(), dapo_args=dapo_args_1
+        )
+        # final_rewards_1 is (batch, action_len). Value is at last token.
+        assert_close(final_rewards_1[0, -1], _t(expected_reward_output_1_seq0_val))
+        assert_close(final_rewards_1[1, -1], _t(expected_reward_output_1_seq1_val))
+
+
+        # Test Case 2: l_max - l_cache < length <= l_max
+        # R_length should be ((l_max - l_cache) - length) / l_cache
+        r_original_2 = _t([1.0])
+        response_lengths_2 = _t([18000]) # 16384 < 18000 <= 20480
+        dapo_args_2 = {
+            "enable_dapo_overlong_reward_shaping": True,
+            "dapo_l_max": 20480,
+            "dapo_l_cache": 4096
+        }
+        expected_r_length_2 = ((20480 - 4096) - 18000) / 4096.0 # (16384 - 18000) / 4096 = -1616 / 4096 = -0.39453125
+        expected_combined_r_2 = r_original_2[0] + expected_r_length_2 # 1.0 - 0.39453125 = 0.60546875
+        
+        final_rewards_2 = compute_reward(
+            r=r_original_2.clone(), kl_coef=0.0, kl=kl_dummy[0:1].clone(), action_mask=action_mask_dummy[0:1].clone(),
+            response_lengths=response_lengths_2.clone(), dapo_args=dapo_args_2
+        )
+        assert_close(final_rewards_2[0, -1], _t(expected_combined_r_2))
+
+
+        # Test Case 3: length > l_max
+        # R_length should be -1.0
+        r_original_3 = _t([1.0])
+        response_lengths_3 = _t([25000]) # > 20480
+        dapo_args_3 = {
+            "enable_dapo_overlong_reward_shaping": True,
+            "dapo_l_max": 20480,
+            "dapo_l_cache": 4096
+        }
+        expected_r_length_3 = -1.0
+        expected_combined_r_3 = r_original_3[0] + expected_r_length_3 # 1.0 - 1.0 = 0.0
+
+        final_rewards_3 = compute_reward(
+            r=r_original_3.clone(), kl_coef=0.0, kl=kl_dummy[0:1].clone(), action_mask=action_mask_dummy[0:1].clone(),
+            response_lengths=response_lengths_3.clone(), dapo_args=dapo_args_3
+        )
+        assert_close(final_rewards_3[0, -1], _t(expected_combined_r_3))
+        
+
+        # Test Case 4: enable_dapo_overlong_reward_shaping is False
+        r_original_4 = _t([1.0])
+        response_lengths_4 = _t([18000]) # Would receive penalty if enabled
+        dapo_args_4 = {
+            "enable_dapo_overlong_reward_shaping": False, # Disabled
+            "dapo_l_max": 20480,
+            "dapo_l_cache": 4096
+        }
+        # R_length should be 0 as it's disabled
+        expected_combined_r_4 = r_original_4[0] # Should be original reward
+        
+        final_rewards_4 = compute_reward(
+            r=r_original_4.clone(), kl_coef=0.0, kl=kl_dummy[0:1].clone(), action_mask=action_mask_dummy[0:1].clone(),
+            response_lengths=response_lengths_4.clone(), dapo_args=dapo_args_4
+        )
+        assert_close(final_rewards_4[0, -1], _t(expected_combined_r_4))
+
+        # Test Case 5: response_lengths is None
+        r_original_5 = _t([1.0])
+        dapo_args_5 = { # enable_dapo_overlong_reward_shaping is True but no response_lengths
+            "enable_dapo_overlong_reward_shaping": True,
+            "dapo_l_max": 20480,
+            "dapo_l_cache": 4096
+        }
+        expected_combined_r_5 = r_original_5[0] # Should be original reward
+        
+        final_rewards_5 = compute_reward(
+            r=r_original_5.clone(), kl_coef=0.0, kl=kl_dummy[0:1].clone(), action_mask=action_mask_dummy[0:1].clone(),
+            response_lengths=None, dapo_args=dapo_args_5
+        )
+        assert_close(final_rewards_5[0, -1], _t(expected_combined_r_5))
+
+        # Test Case 6: dapo_args is None
+        r_original_6 = _t([1.0])
+        response_lengths_6 = _t([18000])
+        expected_combined_r_6 = r_original_6[0] # Should be original reward
+        
+        final_rewards_6 = compute_reward(
+            r=r_original_6.clone(), kl_coef=0.0, kl=kl_dummy[0:1].clone(), action_mask=action_mask_dummy[0:1].clone(),
+            response_lengths=response_lengths_6.clone(), dapo_args=None
+        )
+        assert_close(final_rewards_6[0, -1], _t(expected_combined_r_6))
+
+        # Test Case 7: L_cache is 0 (should default to 1 to avoid div by zero)
+        r_original_7 = _t([1.0])
+        response_lengths_7 = _t([18000]) 
+        dapo_args_7 = {
+            "enable_dapo_overlong_reward_shaping": True,
+            "dapo_l_max": 20480,
+            "dapo_l_cache": 0 # Problematic L_cache
+        }
+        # l_max - l_cache = 20480. length = 18000. So seq_len <= l_max - l_cache (18000 <= 20480)
+        # This should result in r_length = 0
+        # The internal logic float(max(l_cache, 1)) handles l_cache=0.
+        # If seq_len > l_max - l_cache, e.g. 20500 > 20480 - 0
+        # And seq_len <= l_max, e.g. 20500 <= 20480 (False)
+        # If seq_len = 20480, then r_length = ((20480-0) - 20480) / 1.0 = 0
+        # If seq_len = 20470, then r_length = ((20480-0) - 20470) / 1.0 = 10. This is wrong, penalty should be negative.
+        # The formula is ((Lmax - Lcache) - length) / Lcache.
+        # If Lcache=0, effective Lcache=1.
+        # Lmax_eff = Lmax - 1 = 20479.
+        # If length = 18000. Then 18000 <= 20479. So r_length = 0.
+        expected_combined_r_7 = r_original_7[0] + 0.0
+
+        final_rewards_7 = compute_reward(
+            r=r_original_7.clone(), kl_coef=0.0, kl=kl_dummy[0:1].clone(), action_mask=action_mask_dummy[0:1].clone(),
+            response_lengths=response_lengths_7.clone(), dapo_args=dapo_args_7
+        )
+        assert_close(final_rewards_7[0, -1], _t(expected_combined_r_7))
+
+        # Test Case 8: L_cache is 0, length is between Lmax-Lcache_eff and Lmax
+        # Lmax = 20480, Lcache = 0 (eff_Lcache = 1). Threshold = Lmax - eff_Lcache = 20479
+        # length = 20480. So 20479 < 20480 <= 20480.
+        # r_length = ((20480 - 1) - 20480) / 1 = -1.0
+        r_original_8 = _t([1.0])
+        response_lengths_8 = _t([20480]) 
+        dapo_args_8 = {
+            "enable_dapo_overlong_reward_shaping": True,
+            "dapo_l_max": 20480,
+            "dapo_l_cache": 0 
+        }
+        expected_r_length_8 = -1.0 
+        expected_combined_r_8 = r_original_8[0] + expected_r_length_8 # 1.0 - 1.0 = 0.0
+        final_rewards_8 = compute_reward(
+            r=r_original_8.clone(), kl_coef=0.0, kl=kl_dummy[0:1].clone(), action_mask=action_mask_dummy[0:1].clone(),
+            response_lengths=response_lengths_8.clone(), dapo_args=dapo_args_8
+        )
+        assert_close(final_rewards_8[0, -1], _t(expected_combined_r_8))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/openrlhf/tests/test_ppo_trainer_utils.py
+++ b/openrlhf/tests/test_ppo_trainer_utils.py
@@ -1,0 +1,275 @@
+import unittest
+from types import SimpleNamespace
+import torch # Only if absolutely necessary for type hints, try to keep logic pythonic for this test
+
+# Helper function to simulate the dynamic filtering logic
+def dynamic_filtering_logic_sim(
+    rollout_samples_groups, # List of lists of mocked Sample objects
+    n_samples_per_prompt,
+    dynamic_filtering_reward_range: tuple 
+):
+    filtered_prompt_groups = []
+    for batch_samples_group in rollout_samples_groups:
+        if not batch_samples_group: 
+            continue
+            
+        if len(batch_samples_group) < n_samples_per_prompt:
+            # This might happen at the end of a dataset, or if upstream logic changes.
+            # For testing the filter itself, we mostly assume valid groups are passed.
+            # However, the core logic should be robust to this.
+            # The current PPO trainer's loop structure for dynamic filtering implies
+            # `batch_samples` will always have `n_samples_per_prompt` items.
+            # If not, it means the group is incomplete and likely shouldn't be processed
+            # or this is an error condition from the data source.
+            # For this simulation, we'll skip incomplete groups as they wouldn't form a full "G" set.
+            continue
+
+        rewards_for_prompt_group = [s.rewards[0] for s in batch_samples_group]
+        
+        avg_reward = sum(rewards_for_prompt_group) / len(rewards_for_prompt_group) if rewards_for_prompt_group else 0.0
+        
+        min_r, max_r = dynamic_filtering_reward_range
+        # Keep if the avg_reward is strictly within the specified range
+        if min_r + 1e-6 < avg_reward < max_r - 1e-6:
+            filtered_prompt_groups.append(batch_samples_group)
+            
+    return filtered_prompt_groups
+
+class TestDynamicFiltering(unittest.TestCase): # Renamed class
+
+    def test_original_dynamic_filtering_logic(self):
+        n_samples_per_prompt = 3
+
+        # Test Case 1: Mixed Rewards - Kept (avg_reward = 0.5, range = (0.4, 0.6))
+        group1 = [SimpleNamespace(rewards=[1.0]), SimpleNamespace(rewards=[0.5]), SimpleNamespace(rewards=[0.0])] # avg = 0.5
+        test_range1 = (0.4, 0.6)
+        filtered1 = dynamic_filtering_logic_sim([group1], n_samples_per_prompt, test_range1)
+        self.assertEqual(len(filtered1), 1, "Test Case 1 Failed: Group should be kept")
+        self.assertIn(group1, filtered1)
+
+        # Test Case 2: Mixed Rewards - Discarded (avg_reward = 0.5, range = (0.0, 0.4))
+        group2 = [SimpleNamespace(rewards=[1.0]), SimpleNamespace(rewards=[0.5]), SimpleNamespace(rewards=[0.0])] # avg = 0.5
+        test_range2 = (0.0, 0.4)
+        filtered2 = dynamic_filtering_logic_sim([group2], n_samples_per_prompt, test_range2)
+        self.assertEqual(len(filtered2), 0, "Test Case 2 Failed: Group should be discarded")
+
+        # Test Case 3: All Identical Rewards - Kept (avg_reward = 1.0, range = (0.0, 1.1))
+        group3 = [SimpleNamespace(rewards=[1.0]), SimpleNamespace(rewards=[1.0]), SimpleNamespace(rewards=[1.0])] # avg = 1.0
+        test_range3 = (0.0, 1.1)
+        filtered3 = dynamic_filtering_logic_sim([group3], n_samples_per_prompt, test_range3)
+        self.assertEqual(len(filtered3), 1, "Test Case 3 Failed: Group should be kept")
+        self.assertIn(group3, filtered3)
+
+        # Test Case 4: All Identical Rewards - Discarded (avg_reward = 1.0, range = (0.0, 1.0))
+        group4 = [SimpleNamespace(rewards=[1.0]), SimpleNamespace(rewards=[1.0]), SimpleNamespace(rewards=[1.0])] # avg = 1.0
+        test_range4 = (0.0, 1.0) # Upper bound is exclusive due to "< max_r - 1e-6"
+        filtered4 = dynamic_filtering_logic_sim([group4], n_samples_per_prompt, test_range4)
+        self.assertEqual(len(filtered4), 0, "Test Case 4 Failed: Group should be discarded")
+
+        # Test Case 5: Edge Case - Avg Reward equals Lower Bound (Strict Inequality)
+        group5 = [SimpleNamespace(rewards=[0.1]), SimpleNamespace(rewards=[0.1]), SimpleNamespace(rewards=[0.1])] # avg = 0.1
+        test_range5 = (0.1, 0.5) # Lower bound is exclusive due to "min_r + 1e-6 <"
+        filtered5 = dynamic_filtering_logic_sim([group5], n_samples_per_prompt, test_range5)
+        self.assertEqual(len(filtered5), 0, "Test Case 5 Failed: Group should be discarded")
+
+        # Test Case 6: Edge Case - Avg Reward equals Upper Bound (Strict Inequality)
+        group6 = [SimpleNamespace(rewards=[0.5]), SimpleNamespace(rewards=[0.5]), SimpleNamespace(rewards=[0.5])] # avg = 0.5
+        test_range6 = (0.1, 0.5) # Upper bound is exclusive
+        filtered6 = dynamic_filtering_logic_sim([group6], n_samples_per_prompt, test_range6)
+        self.assertEqual(len(filtered6), 0, "Test Case 6 Failed: Group should be discarded")
+        
+        # Test multiple groups
+        all_groups = [group1, group2, group3, group4, group5, group6]
+        # Range that keeps group1 (avg 0.5) and group3 (avg 1.0)
+        # range = (0.4, 1.05)
+        # group1 (0.5) -> keep (0.4 < 0.5 < 1.05)
+        # group2 (0.5) -> keep (same as group1, logic based on range)
+        # group3 (1.0) -> keep (0.4 < 1.0 < 1.05)
+        # group4 (1.0) -> keep (same as group3)
+        # group5 (0.1) -> discard
+        # group6 (0.5) -> keep
+        multi_range = (0.4, 1.05)
+        filtered_multi = dynamic_filtering_logic_sim(all_groups, n_samples_per_prompt, multi_range)
+        self.assertEqual(len(filtered_multi), 4) # group1, group2(same as 1), group3, group4(same as 3), group6
+        self.assertIn(group1, filtered_multi)
+        self.assertNotIn(group2, filtered_multi) # group2 avg 0.5, but original range was (0.0, 0.4) making it fail. Here it should pass.
+                                                  # Ah, group2 is identical to group1. So if group1 passes, group2 passes with same range.
+                                                  # The test is about the *range*.
+                                                  # For multi_range=(0.4, 1.05):
+                                                  # G1 (avg 0.5) -> Kept
+                                                  # G2 (avg 0.5) -> Kept
+                                                  # G3 (avg 1.0) -> Kept
+                                                  # G4 (avg 1.0) -> Kept
+                                                  # G5 (avg 0.1) -> Discarded
+                                                  # G6 (avg 0.5) -> Kept
+        # Re-evaluating 'filtered_multi' with multi_range = (0.4, 1.05)
+        # Group1 (avg 0.5): 0.4 + 1e-6 < 0.5 < 1.05 - 1e-6 -> True (Keep)
+        # Group2 (avg 0.5): 0.4 + 1e-6 < 0.5 < 1.05 - 1e-6 -> True (Keep)
+        # Group3 (avg 1.0): 0.4 + 1e-6 < 1.0 < 1.05 - 1e-6 -> True (Keep)
+        # Group4 (avg 1.0): 0.4 + 1e-6 < 1.0 < 1.05 - 1e-6 -> True (Keep)
+        # Group5 (avg 0.1): 0.4 + 1e-6 < 0.1 < 1.05 - 1e-6 -> False (Discard)
+        # Group6 (avg 0.5): 0.4 + 1e-6 < 0.5 < 1.05 - 1e-6 -> True (Keep)
+        # Expected: group1, group2, group3, group4, group6. Length = 5.
+        self.assertEqual(len(filtered_multi), 5)
+        self.assertIn(group1, filtered_multi)
+        self.assertIn(group2, filtered_multi) # This will be the same object as group1 if inputs are not deepcopied by test logic
+        self.assertIn(group3, filtered_multi)
+        self.assertIn(group4, filtered_multi) # Same as group3
+        self.assertNotIn(group5, filtered_multi)
+        self.assertIn(group6, filtered_multi)
+
+
+    def test_dynamic_filtering_empty_input(self):
+        # Using the simplified helper
+        filtered = dynamic_filtering_logic_sim([], n_samples_per_prompt=3, dynamic_filtering_reward_range=(0.0, 1.0))
+        self.assertEqual(len(filtered), 0, "Filtering empty list should result in empty list")
+
+    def test_dynamic_filtering_single_sample_per_prompt(self):
+        # With n_samples_per_prompt=1, avg_reward is just the reward of that single sample.
+        group_g1_kept = [SimpleNamespace(rewards=[0.5])]    # avg = 0.5
+        group_g1_discarded = [SimpleNamespace(rewards=[1.0])] # avg = 1.0
+        
+        test_range = (0.0, 0.9) # Keeps 0.5 (0.0 < 0.5 < 0.9), discards 1.0
+        
+        filtered_kept = dynamic_filtering_logic_sim([group_g1_kept], n_samples_per_prompt=1, dynamic_filtering_reward_range=test_range)
+        self.assertEqual(len(filtered_kept), 1)
+        self.assertIn(group_g1_kept, filtered_kept)
+        
+        filtered_discarded = dynamic_filtering_logic_sim([group_g1_discarded], n_samples_per_prompt=1, dynamic_filtering_reward_range=test_range)
+        self.assertEqual(len(filtered_discarded), 0)
+
+        # Test with G=1 and range that discards all
+        filtered_all_discard = dynamic_filtering_logic_sim(
+            [group_g1_kept, group_g1_discarded], 
+            n_samples_per_prompt=1, 
+            dynamic_filtering_reward_range=(2.0, 3.0) # No reward (0.5 or 1.0) is in this range
+        )
+        self.assertEqual(len(filtered_all_discard), 0)
+
+
+# Helper function for Overlong Filtering Test
+def dapo_overlong_filtering_logic_sim(
+    sequences_list_of_lists, # List of Python lists of token IDs
+        prompt_group2_g1 = [SimpleNamespace(rewards=[-1.0])]
+        
+        all_prompt_groups_g1 = [prompt_group1_g1, prompt_group2_g1]
+        filtered_g1 = dapo_dynamic_filtering_logic(all_prompt_groups_g1, n_samples_per_prompt=1)
+        self.assertEqual(len(filtered_g1), 0, "With G=1, all groups should be filtered out")
+
+# Helper function for Overlong Filtering Test
+def dapo_overlong_filtering_logic_sim(
+    sequences_list_of_lists, # List of Python lists of token IDs
+    attention_masks_list_of_lists, # List of Python lists for attention masks
+    action_masks_initial_pt, # PyTorch tensor (batch, action_len)
+    max_len, 
+    eos_token_id,
+    pad_token_id # Assuming sequences might be padded to a common length in reality
+):
+    action_masks_modified_pt = action_masks_initial_pt.clone()
+    
+    for i in range(len(sequences_list_of_lists)):
+        # Simulate how actual length is determined from attention_mask
+        # In the real code, sequences_in_obj[i, current_seq_len - 1] uses tensor slicing
+        # Here, we directly use the sum of attention_mask to get true length
+        
+        current_seq_len = sum(attention_masks_list_of_lists[i])
+        
+        # Get the last actual token ID before padding
+        # For simplicity, assume sequences_list_of_lists contains unpadded sequences for this check
+        # or that current_seq_len correctly points to the last valid token in a potentially padded sequence.
+        # The original code uses `sequences_in_obj[i, current_seq_len - 1].item()`.
+        # We need to find the token at `current_seq_len - 1` within the original sequence.
+        
+        last_token_id = -1 # Default if sequence is empty or fully padded
+        if current_seq_len > 0:
+            # Find the (current_seq_len - 1)-th '1' in attention_masks_list_of_lists[i]
+            # This gives the index in the padded sequence.
+            # Example: seq = [10,20,30,0,0], att = [1,1,1,0,0], current_seq_len = 3. last_token_idx_in_padded = 2. token = 30.
+            # Example: seq = [10,20,30,2,0], att = [1,1,1,1,0], current_seq_len = 4. last_token_idx_in_padded = 3. token = 2.
+            
+            # Find the index of the last valid token
+            last_valid_token_index = -1
+            temp_len = 0
+            for k_idx, token_in_seq in enumerate(sequences_list_of_lists[i]):
+                if attention_masks_list_of_lists[i][k_idx] == 1:
+                    temp_len +=1
+                    if temp_len == current_seq_len:
+                        last_valid_token_index = k_idx
+                        break
+            if last_valid_token_index != -1:
+                 last_token_id = sequences_list_of_lists[i][last_valid_token_index]
+
+        is_truncated = (current_seq_len == max_len) and (last_token_id != eos_token_id)
+        
+        if is_truncated:
+            action_masks_modified_pt[i, :] = False
+            
+    return action_masks_modified_pt
+
+class TestDAPOOverlongFiltering(unittest.TestCase):
+    def test_overlong_filtering(self):
+        max_len = 5
+        eos_token_id = 2
+        pad_token_id = 0 # Assuming 0 is pad
+
+        # Case 1: Shorter than max_len
+        seq1 = [10, 20, 30, eos_token_id, pad_token_id] 
+        att1 = [1,  1,  1,  1,  0] # actual len 4
+        # Case 2: Equals max_len, ends with EOS
+        seq2 = [10, 20, 30, 40, eos_token_id]
+        att2 = [1,  1,  1,  1,  1] # actual len 5
+        # Case 3: Equals max_len, truncated (does not end with EOS)
+        seq3 = [10, 20, 30, 40, 50] 
+        att3 = [1,  1,  1,  1,  1] # actual len 5
+        # Case 4: Shorter, no EOS (implicitly truncated by data, but not by max_len rule)
+        seq4 = [10, 20, 30, pad_token_id, pad_token_id]
+        att4 = [1,  1,  1,  0,  0] # actual len 3
+
+        sequences_ll = [seq1, seq2, seq3, seq4]
+        att_masks_ll = [att1, att2, att3, att4]
+        
+        # Assuming action_mask corresponds to some response part, let's say last 2 tokens if possible
+        # For simplicity, let's make initial action_masks all True for relevant parts
+        # The length of action_mask is tied to response, not total sequence in PolicyLoss.
+        # However, the filtering logic zeros out the *entire* action_mask row for a truncated sample.
+        # Let's assume action_mask has a fixed length for testing.
+        action_mask_len = 3 
+        initial_action_masks = torch.ones((len(sequences_ll), action_mask_len), dtype=torch.bool)
+
+        modified_masks = dapo_overlong_filtering_logic_sim(
+            sequences_ll, att_masks_ll, initial_action_masks, max_len, eos_token_id, pad_token_id
+        )
+
+        # Case 1: Not truncated, mask should be unchanged
+        self.assertTrue(torch.all(modified_masks[0] == initial_action_masks[0]).item(), "Case 1 failed: Mask should be unchanged.")
+        
+        # Case 2: Not truncated (EOS at max_len), mask should be unchanged
+        self.assertTrue(torch.all(modified_masks[1] == initial_action_masks[1]).item(), "Case 2 failed: Mask should be unchanged.")
+
+        # Case 3: Truncated (max_len, no EOS), mask should be all False
+        self.assertTrue(torch.all(modified_masks[2] == False).item(), "Case 3 failed: Mask should be all False.")
+        
+        # Case 4: Not truncated by max_len rule, mask should be unchanged
+        self.assertTrue(torch.all(modified_masks[3] == initial_action_masks[3]).item(), "Case 4 failed: Mask should be unchanged.")
+
+    def test_overlong_filtering_empty_sequence(self):
+        # Edge case: empty sequence or fully padded
+        max_len = 5
+        eos_token_id = 2
+        pad_token_id = 0
+        seq1 = [pad_token_id, pad_token_id, pad_token_id, pad_token_id, pad_token_id]
+        att1 = [0,0,0,0,0] # actual len 0
+        sequences_ll = [seq1]
+        att_masks_ll = [att1]
+        action_mask_len = 3
+        initial_action_masks = torch.ones((1, action_mask_len), dtype=torch.bool)
+
+        modified_masks = dapo_overlong_filtering_logic_sim(
+            sequences_ll, att_masks_ll, initial_action_masks, max_len, eos_token_id, pad_token_id
+        )
+        # Not truncated by max_len rule (length 0 != 5)
+        self.assertTrue(torch.all(modified_masks[0] == initial_action_masks[0]).item(), "Empty sequence case failed.")
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/openrlhf/trainer/ppo_trainer.py
+++ b/openrlhf/trainer/ppo_trainer.py
@@ -488,12 +488,13 @@ class PPOTrainer(BasePPOTrainer):
                             continue
 
                         # Calculate average reward for this batch of samples
-                        avg_reward = sum(sample.rewards[0] for sample in batch_samples) / len(batch_samples)
-
+                        avg_reward = sum(s.rewards[0] for s in batch_samples) / len(batch_samples)
+                        
                         # Check if average reward is within the specified range
-                        min_reward, max_reward = self.args.dynamic_filtering_reward_range
-                        if min_reward + 1e-6 < avg_reward < max_reward - 1e-6:
+                        min_r, max_r = self.args.dynamic_filtering_reward_range
+                        if min_r + 1e-6 < avg_reward < max_r - 1e-6: # Ensure strict inequality
                             filtered_samples.extend(batch_samples)
+                        # Else, the prompt and its samples are discarded
 
                     # Continue sampling if filtered samples are insufficient
                     if len(filtered_samples) / self.args.n_samples_per_prompt < self.args.rollout_batch_size:

--- a/openrlhf/trainer/ray/ppo_actor.py
+++ b/openrlhf/trainer/ray/ppo_actor.py
@@ -42,7 +42,9 @@ class ActorPPOTrainer(ABC):
         micro_train_batch_size: int = 8,
         buffer_limit: int = 0,
         buffer_cpu_offload: bool = True,
-        eps_clip: float = 0.2,
+        eps_clip: float = 0.2, # Keep for compatibility if ValueLoss uses it, or for other PPO variants
+        dapo_clip_eps_low: float = 0.2,
+        dapo_clip_eps_high: float = 0.28,
         tokenizer=None,
         dataloader_pin_memory: bool = True,
         vllm_engines: List = None,
@@ -68,7 +70,7 @@ class ActorPPOTrainer(ABC):
         self.vllm_engines = vllm_engines
         self.max_epochs = self.args.max_epochs
 
-        self.actor_loss_fn = PolicyLoss(eps_clip)
+        self.actor_loss_fn = PolicyLoss(clip_eps_low=dapo_clip_eps_low, clip_eps_high=dapo_clip_eps_high)
         # DisCO Loss (initialized if needed in training_step)
         self.disco_loss_fn = None
 
@@ -541,7 +543,9 @@ class ActorModelRayActor(BasePPORole):
             actor_scheduler=self.actor_scheduler,
             micro_train_batch_size=args.micro_train_batch_size,
             tokenizer=self.tokenizer,
-            eps_clip=args.eps_clip,
+            eps_clip=args.eps_clip, # Keep for other potential uses or if ValueLoss needs it
+            dapo_clip_eps_low=args.dapo_clip_eps_low,
+            dapo_clip_eps_high=args.dapo_clip_eps_high,
             ema_beta=args.ema_beta,
             vllm_engines=self.vllm_engines,
         )


### PR DESCRIPTION
This commit further updates the dynamic sampling logic based on your clarification. The behavior is reverted to the original OpenRLHF method for dynamic filtering.

The updated logic is as follows:
- For any prompt and its G sampled responses, calculate the average reward (`avg_reward`).
- The prompt and its samples are kept if and only if this `avg_reward` strictly falls within the user-defined `dynamic_filtering_reward_range` (i.e., `min_reward + 1e-6 < avg_reward < max_reward - 1e-6`).
- Any checks related to whether all rewards are the same (all_rewards_same) have been removed from this filtering decision.

This change modifies the filtering conditions in `PPOTrainer.fit` and updates the corresponding unit tests in `openrlhf/tests/test_ppo_trainer_utils.py` to reflect this reverted logic.